### PR TITLE
Updates PyTest task version

### DIFF
--- a/PyTest/task.json
+++ b/PyTest/task.json
@@ -12,8 +12,8 @@
     "author": "Steve Dower",
     "version": {
         "Major": 1,
-        "Minor": 0,
-        "Patch": 3
+        "Minor": 1,
+        "Patch": 0
     },
     "minimumAgentVersion": "2.0",
     "groups": [


### PR DESCRIPTION
@dciborow Just FYI, since you did the original PR, the task version number has to increase for every change or it won't be picked up. Generally I change `patch` for fixes and `minor` for non-breaking field changes.